### PR TITLE
Update stylelint to allow unit-less CSS variables

### DIFF
--- a/configs/stylelint.config.js
+++ b/configs/stylelint.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: "stylelint-config-sass-guidelines",
   rules: {
+    // Without this exception, stylelint will incorrectly append "px" to any "0" value, which can break calc() functions
     "length-zero-no-unit": [true, {
       ignore: ["custom-properties"],
     }],


### PR DESCRIPTION
## Ticket
[Notion](https://www.notion.so/teamshares/Follow-up-PRs-to-shared-ui-and-teamshares-rails-724f4e49861940ee9d0d972342776855?pvs=4)

## Description
This rule already exists in OS, and is necessary for using `calc()` with custom variables. Stylelint kept automatically (and incorrectly) appending `px` to the end of `0` length units, breaking the CSS.

