### PR TITLE
Experimenting with making dependencies NOT dev-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,6 @@
     "@tailwindcss/forms": "0.5.6",
     "@tailwindcss/typography": "0.5.10",
     "@teamshares/shoelace": "^1.3.0",
-    "tailwindcss": "3.3.3"
-  },
-  "devDependencies": {
-    "concurrently": "^8.2.1",
     "cssnano": "^6.0.1",
     "esbuild": "^0.19.2",
     "esbuild-plugin-copy": "^2.1.1",
@@ -31,15 +27,18 @@
     "eslint-plugin-n": "^16.0.2",
     "eslint-plugin-promise": "^6.1.1",
     "globals": "^13.21.0",
-    "husky": "8.0.3",
-    "is-ci": "3.0.1",
-    "lint-staged": "14.0.1",
     "postcss": "^8.4.29",
     "postcss-easy-import": "^4.0.0",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-preset-env": "^9.1.2",
     "postcss-reporter": "^7.0.5",
+    "tailwindcss": "3.3.3",
     "stylelint": "^15.0.0",
     "stylelint-config-sass-guidelines": "^10.0.0"
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.1",
+    "husky": "8.0.3",
+    "lint-staged": "14.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -873,11 +873,6 @@ chalk@^4.0.0, chalk@^4.1.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-ci-info@^3.2.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
-  integrity sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==
-
 cli-cursor@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-4.0.0.tgz#3cecfe3734bf4fe02a8361cbdc0f6fe28c6a57ea"
@@ -1835,13 +1830,6 @@ is-binary-path@~2.1.0:
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
-
-is-ci@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
-  integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
-  dependencies:
-    ci-info "^3.2.0"
 
 is-core-module@^2.12.1, is-core-module@^2.13.0:
   version "2.13.0"


### PR DESCRIPTION
Wondering if we can prevent having to re-create the list of e.g. eslint plugins in every consuming app...