### PR TITLE
Remove manual JS importing (will pull as actual JS package)

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,2 +1,4 @@
+#!/bin/bash
+
 yarn
 yarn husky install

--- a/configs/esbuild.config.js
+++ b/configs/esbuild.config.js
@@ -68,9 +68,9 @@ const sharedConfig = {
     "process.env.HEROKU_SLUG_COMMIT": `"${process.env.SOURCE_VERSION || process.env.HEROKU_SLUG_COMMIT}"`,
   },
   plugins: [
-    EsbuildPluginResolve({
-      "@teamshares-rails": path.join(tsRailsPath, "app/javascript/teamshares-rails"),
-    }),
+    // EsbuildPluginResolve({
+    //   "@teamshares-rails": path.join(tsRailsPath, "app/javascript/teamshares-rails"),
+    // }),
     stimulusPlugin(),
     copy({
       // this is equal to process.cwd(), which means we use cwd path as base path to resolve `to` path

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "name": "@teamshares/design-system",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/teamshares/design-system.git"
+  },
   "version": "0.0.1",
   "private": true,
   "files": [


### PR DESCRIPTION
## Ticket
[Notion](https://www.notion.so/teamshares/shared-ui-design-system-fa98885cb96841bd86942794303e353f)

## Description
Previously we were using a manual esbuild resolver config to link to teamshares-rails JS -- now we're going to reference it directly as a dependency in `package.json`.