### PR TITLE
JS back to @teamshares/design-system

### DIFF
--- a/configs/esbuild.config.js
+++ b/configs/esbuild.config.js
@@ -3,12 +3,12 @@ const path = require("path");
 const esbuild = require("esbuild");
 const { stimulusPlugin } = require("esbuild-plugin-stimulus");
 const { copy } = require("esbuild-plugin-copy");
-const { getTeamsharesRailsPath } = require("../lib/teamshares-rails-path");
+
+// const { getTeamsharesRailsPath } = require("../lib/teamshares-rails-path");
+// const tsRailsPath = getTeamsharesRailsPath();
 
 const isProd = process.env.RAILS_ENV === "production" || process.env.NODE_ENV === "production";
 const isWatch = process.argv.includes("--watch");
-
-const tsRailsPath = getTeamsharesRailsPath();
 
 // --- Start inlining esbuild-plugin-resolve ---
 //

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,10 +1,14 @@
 const { buildConfigs } = require("./configs/eslint.config.js");
 
-const { nodeConfig } = buildConfigs();
+const { browserConfig, nodeConfig } = buildConfigs();
 
 module.exports = [
   {
     files: ["*.config.js", "lib/teamshares-rails-path.js"],
     ...nodeConfig,
+  },
+  {
+    files: ["rails-js/**/*.js"],
+    ...browserConfig,
   },
 ];

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "private": true,
   "files": [
     "scss/**/*.scss",
-    "configs/*.js"
+    "configs/*.js",
+    "rails-js/**/*.js"
   ],
   "main": "scss/index.scss",
   "scripts": {
@@ -18,6 +19,10 @@
     "precommit": "lint-staged --quiet"
   },
   "dependencies": {
+    "@honeybadger-io/js": "^6.4.1",
+    "@hotwired/stimulus": "^3.2.2",
+    "@hotwired/turbo-rails": "7.3.0",
+    "@rails/ujs": "7.0.8",
     "@tailwindcss/forms": "0.5.6",
     "@tailwindcss/typography": "0.5.10",
     "@teamshares/shoelace": "^1.3.0",
@@ -31,6 +36,7 @@
     "eslint-plugin-n": "^16.0.2",
     "eslint-plugin-promise": "^6.1.1",
     "globals": "^13.21.0",
+    "inputmask": "^5.0.8",
     "postcss": "^8.4.29",
     "postcss-easy-import": "^4.0.0",
     "postcss-flexbugs-fixes": "^5.0.2",

--- a/rails-js/_honeybadger.js
+++ b/rails-js/_honeybadger.js
@@ -1,0 +1,39 @@
+import Honeybadger from "@honeybadger-io/js";
+
+// The next line tells eslint to accept the undef vars (these are specifically injected into esbuild's build process)
+/* global process */
+const HEROKU_APP_NAME = process.env.HEROKU_APP_NAME;
+const RAILS_ENV = process.env.RAILS_ENV;
+const HONEYBADGER_JS_API_KEY = process.env.HONEYBADGER_JS_API_KEY;
+const HEROKU_SLUG_COMMIT = process.env.HEROKU_SLUG_COMMIT;
+
+const getAppContext = () => {
+  const heroku = HEROKU_APP_NAME || "";
+  if (heroku.length === 0) return;
+
+  return heroku.includes("-production") ? "production" : (heroku.includes("-staging") ? "staging" : "review");
+};
+
+export const initHoneybadger = (opts = {}) => {
+  if (RAILS_ENV !== "production") return;
+
+  const appContext = getAppContext();
+  if (!appContext) {
+    console.log("WARN: production-ish environment is missing HEROKU_APP_NAME -- NOT initializing Honeybadger");
+    return;
+  }
+
+  if (!HONEYBADGER_JS_API_KEY) {
+    console.log(`Honeybadger not configured -- set HONEYBADGER_JS_API_KEY to enable (for ${HEROKU_APP_NAME})`);
+    return;
+  }
+
+  const config = Object.assign({
+    apiKey: HONEYBADGER_JS_API_KEY,
+    environment: appContext,
+    revision: HEROKU_SLUG_COMMIT,
+  }, opts);
+
+  Honeybadger.configure(config);
+  window.Honeybadger = Honeybadger;
+};

--- a/rails-js/controllers/index.js
+++ b/rails-js/controllers/index.js
@@ -1,0 +1,4 @@
+import InputMaskController from "./input_mask_controller";
+import ToggleController from "./toggle_controller";
+
+export { InputMaskController, ToggleController };

--- a/rails-js/controllers/input_mask_controller.js
+++ b/rails-js/controllers/input_mask_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus";
+import Inputmask from "inputmask";
+
+export default class extends Controller {
+  connect () {
+    Inputmask(this.data.get("pattern")).mask(this.element);
+  }
+}

--- a/rails-js/controllers/toggle_controller.js
+++ b/rails-js/controllers/toggle_controller.js
@@ -1,0 +1,45 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["toggleable"];
+  static classes = ["toggle"];
+
+  connect () {
+    this.element[this.identifier] = this;
+    this.classToToggle = this.hasToggleClass ? this.toggleClass : "hidden";
+    this.externalTargets = document.getElementsByClassName(this.data.get("externalTargetClass"));
+  }
+
+  classIsApplied () {
+    return this.element.classList.contains(this.classToToggle);
+  }
+
+  toggle (event) {
+    if (!this.data.has("allowDefault")) event.preventDefault();
+
+    this.toggleControllerTargets();
+    this.toggleExternalTargets();
+  }
+
+  toggleOff (event) {
+    if (!this.data.has("allowDefault")) event.preventDefault();
+
+    if (this.classIsApplied()) this.toggle(event);
+  }
+
+  toggleControllerTargets () {
+    this.toggleableTargets.forEach(target => {
+      this.toggleElementClassList(target);
+    });
+  }
+
+  toggleExternalTargets () {
+    for (let i = 0; i < this.externalTargets.length; ++i) {
+      this.toggleElementClassList(this.externalTargets[i]);
+    }
+  }
+
+  toggleElementClassList (targetElement) {
+    targetElement.classList.toggle(this.classToToggle);
+  }
+}

--- a/rails-js/index.js
+++ b/rails-js/index.js
@@ -1,0 +1,62 @@
+import * as Shoelace from "@teamshares/shoelace";
+import { initHoneybadger } from "./_honeybadger";
+// Importing this as a default param so the init doesn't break if apps don't pass it in
+import Rails from "@rails/ujs";
+
+export * from "./controllers";
+
+/** ********************************************************** */
+/**  Apps should import Teamshares and call init() on startup  */
+/** ********************************************************** */
+export default class Teamshares {
+  static init (railsObj = Rails) {
+    console.log("Initializing Teamshares JS");
+    initHoneybadger({ debug: true });
+
+    // Overwrite Rails UJS's selectors to include Shoelace elements
+    railsObj.buttonClickSelector = {
+      selector: railsObj.buttonClickSelector.selector + ", sl-button[data-remote]:not([form]), sl-button[data-confirm]:not([form])",
+      exclude: "form button, form sl-button",
+    };
+    railsObj.linkClickSelector += ", sl-button[href][data-confirm], sl-button[href][data-method], sl-button[href][data-remote]:not([disabled]), sl-button[href][data-disable-with], sl-button[href][data-disable]";
+    railsObj.inputChangeSelector += ", sl-select[data-remote], sl-input[data-remote], sl-textarea[data-remote]";
+    railsObj.formInputClickSelector += ", form:not([data-turbo=true]) sl-input[type=submit], form:not([data-turbo=true]) sl-input[type=image], form:not([data-turbo=true]) sl-button[type=submit], form:not([data-turbo=true]) sl-button:not([type]), sl-input[type=submit][form], sl-input[type=image][form], sl-button[type=submit][form], sl-button[form]:not([type])";
+    railsObj.formDisableSelector += ", sl-input[data-disable-with]:enabled, sl-button[data-disable-with]:enabled, sl-textarea[data-disable-with]:enabled, sl-input[data-disable]:enabled, sl-button[data-disable]:enabled, sl-textarea[data-disable]:enabled";
+    railsObj.formEnableSelector += ", sl-input[data-disable-with]:disabled, sl-button[data-disable-with]:disabled, sl-textarea[data-disable-with]:disabled, sl-input[data-disable]:disabled, sl-button[data-disable]:disabled, sl-textarea[data-disable]:disabled";
+    railsObj.fileInputSelector += ", sl-input[name][type=file]:not([disabled])";
+    railsObj.linkDisableSelector += ", sl-button[href][data-disable-with], sl-button[href][data-disable]";
+    railsObj.buttonDisableSelector += ", sl-button[data-remote][data-disable-with], sl-button[data-remote][data-disable]";
+
+    // Register free font-awesome icons
+    Shoelace.registerIconLibrary("fa-free", {
+      resolver: name => {
+        const filename = name.replace(/^fa[rbs]-/, "");
+        let folder = "regular";
+        if (name.substring(0, 4) === "fas-") folder = "solid";
+        if (name.substring(0, 4) === "fab-") folder = "brands";
+        return `https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.3.0/svgs/${folder}/${filename}.svg`;
+      },
+      mutator: svg => svg.setAttribute("fill", "currentColor"),
+    });
+
+    // Register FontAwesome Pro and point at our bespoke "kit" URL, including the token in the querystring
+    // See https://fontawesome.com/kits/44da2a9d09/setup
+    // Note that the kit allows us to whitelist / deny specific URL patterns
+    Shoelace.registerIconLibrary("fa", {
+      resolver: name => {
+        const filename = name.replace(/^fa([rsltdb]|(ss))-/, "");
+        const sub = name.substring(0, 4);
+        const folderHash = {
+          "fas-": "solid",
+          "fal-": "light",
+          "fat-": "thin",
+          "fad-": "duotone",
+          "fab-": "brands",
+        };
+        const folder = folderHash[sub] || "regular";
+        return `https://ka-p.fontawesome.com/releases/v6.4.0/svgs/${folder}/${filename}.svg?token=44da2a9d09`;
+      },
+      mutator: svg => svg.setAttribute("fill", "currentColor"),
+    });
+  }
+}

--- a/rails-js/index.js
+++ b/rails-js/index.js
@@ -1,9 +1,8 @@
 import * as Shoelace from "@teamshares/shoelace";
 import { initHoneybadger } from "./_honeybadger";
+
 // Importing this as a default param so the init doesn't break if apps don't pass it in
 import Rails from "@rails/ujs";
-
-export * from "./controllers";
 
 /** ********************************************************** */
 /**  Apps should import Teamshares and call init() on startup  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,6 +466,40 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.3.tgz#6ee493102b45d796d69f1f472d4bf64e5244500a"
   integrity sha512-uvnFKtPgzLnpzzTRfhDlvXX0kLYi9lDRQbcDmT8iXl71Rx+uwSuaUIQl3DNC7w5OweAQ7XQMDObML+KaYDQfng==
 
+"@honeybadger-io/core@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@honeybadger-io/core/-/core-6.3.0.tgz#b61368cd60368ba3729d46fdb2cbe6cffde41d50"
+  integrity sha512-iwLmh7GJCWQoqPrN56zdDfpNccwmUZbUyxTqkVhk16OpHJPz8kgENKHB/U6ZWf5/w43UzoHvxiJN8dAhlYoERg==
+  dependencies:
+    stacktrace-parser "^0.1.10"
+
+"@honeybadger-io/js@^6.4.1":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@honeybadger-io/js/-/js-6.5.0.tgz#34c3ff921700bac5598c8f3f027a062a9bb658fe"
+  integrity sha512-3lUbrs9OpODw/8IIFI0SmNxPekJW3qI+nrsyn/IRyMDWMHY0hvQnx9L+C1dC/jT95IpZDnTEdMXb96e4nSvNtQ==
+  dependencies:
+    "@honeybadger-io/core" "^6.3.0"
+    "@types/aws-lambda" "^8.10.89"
+    "@types/express" "^4.17.13"
+
+"@hotwired/stimulus@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.2.tgz#071aab59c600fed95b97939e605ff261a4251608"
+  integrity sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==
+
+"@hotwired/turbo-rails@7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.3.0.tgz#422c21752509f3edcd6c7b2725bbe9e157815f51"
+  integrity sha512-fvhO64vp/a2UVQ3jue9WTc2JisMv9XilIC7ViZmXAREVwiQ2S4UC7Go8f9A1j4Xu7DBI6SbFdqILk5ImqVoqyA==
+  dependencies:
+    "@hotwired/turbo" "^7.3.0"
+    "@rails/actioncable" "^7.0"
+
+"@hotwired/turbo@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.3.0.tgz#2226000fff1aabda9fd9587474565c9929dbf15d"
+  integrity sha512-Dcu+NaSvHLT7EjrDrkEmH4qET2ZJZ5IcCWmNXxNQTBwlnE5tBZfN6WxZ842n5cHV52DH/AKNirbPBtcEXDLW4g==
+
 "@humanwhocodes/config-array@^0.11.11":
   version "0.11.11"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.11.tgz#88a04c570dbbc7dd943e4712429c3df09bc32844"
@@ -555,6 +589,16 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@rails/actioncable@^7.0":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.8.tgz#f44e7517f2d1570f1eabeea457dbeb17ed3a2d12"
+  integrity sha512-GjYQv89ZOOfbFw8VMNUOG33GXzyAA/TCVoD+742Ob4svm1XXUkd+w+ewqUXd+7VHQtV35y1/O78AGIPeJDTy/g==
+
+"@rails/ujs@7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-7.0.8.tgz#59853367d0827b3955d2c4bedfd5eba4a79d3422"
+  integrity sha512-tOQQBVH8LsUpGXqDnk+kaOGVsgZ8maHAhEiw3Git3p88q+c0Slgu47HuDnL6sVxeCfz24zbq7dOjsVYDiTpDIA==
+
 "@shoelace-style/animations@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@shoelace-style/animations/-/animations-1.1.0.tgz#17539abafd6dcbf2a79e089e1593175e9f7835b5"
@@ -602,15 +646,102 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
+"@types/aws-lambda@^8.10.89":
+  version "8.10.122"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.122.tgz#206c8d71b09325d26a458dba27db842afdc54df1"
+  integrity sha512-vBkIh9AY22kVOCEKo5CJlyCgmSWvasC+SWUxL/x/vOwRobMpI/HG1xp/Ae3AqmSiZeLUbOhW0FCD3ZjqqUxmXw==
+
+"@types/body-parser@*":
+  version "1.19.3"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.3.tgz#fb558014374f7d9e56c8f34bab2042a3a07d25cd"
+  integrity sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
+"@types/connect@*":
+  version "3.4.36"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.36.tgz#e511558c15a39cb29bd5357eebb57bd1459cd1ab"
+  integrity sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==
+  dependencies:
+    "@types/node" "*"
+
+"@types/express-serve-static-core@^4.17.33":
+  version "4.17.37"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.37.tgz#7e4b7b59da9142138a2aaa7621f5abedce8c7320"
+  integrity sha512-ZohaCYTgGFcOP7u6aJOhY9uIZQgZ2vxC2yWoArY+FeDXlqeH66ZVBjgvg+RLVAS/DWNq4Ap9ZXu1+SUQiiWYMg==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+    "@types/send" "*"
+
+"@types/express@^4.17.13":
+  version "4.17.18"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.18.tgz#efabf5c4495c1880df1bdffee604b143b29c4a95"
+  integrity sha512-Sxv8BSLLgsBYmcnGdGjjEjqET2U+AKAdCRODmMiq02FgjwuV75Ut85DRpvFjyw/Mk0vgUOliGRU0UUmuuZHByQ==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.33"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
+
+"@types/http-errors@*":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.2.tgz#a86e00bbde8950364f8e7846687259ffcd96e8c2"
+  integrity sha512-lPG6KlZs88gef6aD85z3HNkztpj7w2R7HmR3gygjfXCQmsLloWNARFkMuzKiiY8FGdh1XDpgBdrSf4aKDiA7Kg==
+
+"@types/mime@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
+  integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
+
+"@types/mime@^1":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
+  integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
+
 "@types/minimist@^1.2.0":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
+"@types/node@*":
+  version "20.6.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.6.5.tgz#4c6a79adf59a8e8193ac87a0e522605b16587258"
+  integrity sha512-2qGq5LAOTh9izcc0+F+dToFigBWiK1phKPt7rNhOqJSr35y8rlIBjDwGtFSgAI6MGIhjwOVNSQZVdJsZJ2uR1w==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
+
+"@types/qs@*":
+  version "6.9.8"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.8.tgz#f2a7de3c107b89b441e071d5472e6b726b4adf45"
+  integrity sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg==
+
+"@types/range-parser@*":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
+  integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
+
+"@types/send@*":
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/@types/send/-/send-0.17.1.tgz#ed4932b8a2a805f1fe362a70f4e62d0ac994e301"
+  integrity sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==
+  dependencies:
+    "@types/mime" "^1"
+    "@types/node" "*"
+
+"@types/serve-static@*":
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.2.tgz#3e5419ecd1e40e7405d34093f10befb43f63381a"
+  integrity sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==
+  dependencies:
+    "@types/http-errors" "*"
+    "@types/mime" "*"
+    "@types/node" "*"
 
 "@types/trusted-types@^2.0.2":
   version "2.0.4"
@@ -1818,6 +1949,11 @@ ini@^1.3.5:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
+inputmask@^5.0.8:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/inputmask/-/inputmask-5.0.8.tgz#cd0f70b058c3291a0d4f27de25dbfc179c998bb4"
+  integrity sha512-1WcbyudPTXP1B28ozWWyFa6QRIUG4KiLoyR6LFHlpT4OfTzRqFfWgHFadNvRuMN1S9XNVz9CdNvCGjJi+uAMqQ==
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -3297,6 +3433,13 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz#7189a474c46f8d47c7b0da4b987bb45e908bd2d5"
   integrity sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==
 
+stacktrace-parser@^0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz#29fb0cae4e0d0b85155879402857a1639eb6051a"
+  integrity sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==
+  dependencies:
+    type-fest "^0.7.1"
+
 string-argv@0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
@@ -3606,6 +3749,11 @@ type-fest@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
+
+type-fest@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
+  integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
 
 type-fest@^0.8.1:
   version "0.8.1"


### PR DESCRIPTION
## Ticket

[Notion](https://www.notion.so/teamshares/shared-ui-design-system-fa98885cb96841bd86942794303e353f)

## Description
*Sigh* unfortunately after jumping through a bunch of hoops to pull JS out into teamshares_rails, I hit an insurmountable snag with heroku's buildpack ordering ([more details here](https://www.notion.so/teamshares/shared-ui-design-system-fa98885cb96841bd86942794303e353f?pvs=4#fe524410c6d24915aec00382095e2372)).  This reverts us to _mostly_ where we were before, but the repos are still renamed and reorganized internally.