### PR TITLE
[JS] Initialize shared libraries from shared code

### DIFF
--- a/configs/eslint.config.js
+++ b/configs/eslint.config.js
@@ -51,7 +51,10 @@ const buildConfigs = (customRules) => {
   const browserConfig = { ...coreConfig };
   browserConfig.languageOptions = {
     ...browserConfig.languageOptions,
-    globals: { ...globals.browser },
+    globals: {
+      Teamshares: "readonly",
+      ...globals.browser
+    },
   };
 
   const nodeConfig = { ...coreConfig };
@@ -65,7 +68,7 @@ const buildConfigs = (customRules) => {
   jestConfig.languageOptions = {
     ...jestConfig.languageOptions,
     globals: {
-      ...globals.browser,
+      ...browserConfig.languageOptions.globals,
 
       // Partial list from manually debugging... will likely need to add additional globals here
       test: false,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "eslint-plugin-n": "^16.0.2",
     "eslint-plugin-promise": "^6.1.1",
     "globals": "^13.21.0",
-    "inputmask": "^5.0.8",
     "postcss": "^8.4.29",
     "postcss-easy-import": "^4.0.0",
     "postcss-flexbugs-fixes": "^5.0.2",

--- a/rails-js/controllers/index.js
+++ b/rails-js/controllers/index.js
@@ -1,4 +1,23 @@
-import InputMaskController from "./input_mask_controller";
+import { Application } from "@hotwired/stimulus";
+
+// Shared controllers
 import ToggleController from "./toggle_controller";
 
-export { InputMaskController, ToggleController };
+const registerStimulusControllers = (appDefinitions) => {
+  const application = Application.start();
+
+  // Register the shared controllers
+  application.register("toggle", ToggleController);
+
+  // Auto-load all app controllers
+  application.load(appDefinitions);
+
+  // Configure Stimulus development experience
+  application.warnings = true;
+  application.debug = false;
+  window.Stimulus = application;
+
+  return application;
+};
+
+export { registerStimulusControllers };

--- a/rails-js/controllers/input_mask_controller.js
+++ b/rails-js/controllers/input_mask_controller.js
@@ -1,8 +1,0 @@
-import { Controller } from "@hotwired/stimulus";
-import Inputmask from "inputmask";
-
-export default class extends Controller {
-  connect () {
-    Inputmask(this.data.get("pattern")).mask(this.element);
-  }
-}

--- a/rails-js/index.js
+++ b/rails-js/index.js
@@ -34,6 +34,7 @@ export default class Teamshares {
   static env = _getEnvContext();
   static deploy_context = _getDeployContext();
   static deployed_app_sha = HEROKU_SLUG_COMMIT;
+  static Rails = Rails;
 
   static init (config = {}) {
     console.log("Initializing Teamshares JS");
@@ -111,3 +112,5 @@ export default class Teamshares {
     });
   }
 }
+
+window.Teamshares = Teamshares;

--- a/rails-js/index.js
+++ b/rails-js/index.js
@@ -1,8 +1,8 @@
 import * as Shoelace from "@teamshares/shoelace";
 import Honeybadger from "@honeybadger-io/js";
 
-// Importing this as a default param so the init doesn't break if apps don't pass it in
 import Rails from "@rails/ujs";
+import { Turbo } from "@hotwired/turbo-rails";
 
 /** ********************************************************** */
 /**  Apps should import Teamshares and call init() on startup  */
@@ -35,8 +35,18 @@ export default class Teamshares {
   static deploy_context = _getDeployContext();
   static deployed_app_sha = HEROKU_SLUG_COMMIT;
 
-  static init (railsObj = Rails) {
+  static init (config = {}) {
     console.log("Initializing Teamshares JS");
+
+    if (config.disableTurboSessionDrive) {
+      // This line disables Turbo Drive globally, which some apps have done
+      // due to Cypress test brittleness and/or just not devoting time to
+      // fully implement.
+      //
+      // In those apps, Turbo Drive can be enabled on individual links
+      // and form submissions by adding data-turbo="true" to the element.
+      Turbo.session.drive = false;
+    }
 
     if (Teamshares.env === "production") {
       if (!HONEYBADGER_JS_API_KEY) {
@@ -53,18 +63,20 @@ export default class Teamshares {
     }
 
     // Overwrite Rails UJS's selectors to include Shoelace elements
-    railsObj.buttonClickSelector = {
-      selector: railsObj.buttonClickSelector.selector + ", sl-button[data-remote]:not([form]), sl-button[data-confirm]:not([form])",
+    Rails.buttonClickSelector = {
+      selector: Rails.buttonClickSelector.selector + ", sl-button[data-remote]:not([form]), sl-button[data-confirm]:not([form])",
       exclude: "form button, form sl-button",
     };
-    railsObj.linkClickSelector += ", sl-button[href][data-confirm], sl-button[href][data-method], sl-button[href][data-remote]:not([disabled]), sl-button[href][data-disable-with], sl-button[href][data-disable]";
-    railsObj.inputChangeSelector += ", sl-select[data-remote], sl-input[data-remote], sl-textarea[data-remote]";
-    railsObj.formInputClickSelector += ", form:not([data-turbo=true]) sl-input[type=submit], form:not([data-turbo=true]) sl-input[type=image], form:not([data-turbo=true]) sl-button[type=submit], form:not([data-turbo=true]) sl-button:not([type]), sl-input[type=submit][form], sl-input[type=image][form], sl-button[type=submit][form], sl-button[form]:not([type])";
-    railsObj.formDisableSelector += ", sl-input[data-disable-with]:enabled, sl-button[data-disable-with]:enabled, sl-textarea[data-disable-with]:enabled, sl-input[data-disable]:enabled, sl-button[data-disable]:enabled, sl-textarea[data-disable]:enabled";
-    railsObj.formEnableSelector += ", sl-input[data-disable-with]:disabled, sl-button[data-disable-with]:disabled, sl-textarea[data-disable-with]:disabled, sl-input[data-disable]:disabled, sl-button[data-disable]:disabled, sl-textarea[data-disable]:disabled";
-    railsObj.fileInputSelector += ", sl-input[name][type=file]:not([disabled])";
-    railsObj.linkDisableSelector += ", sl-button[href][data-disable-with], sl-button[href][data-disable]";
-    railsObj.buttonDisableSelector += ", sl-button[data-remote][data-disable-with], sl-button[data-remote][data-disable]";
+    Rails.linkClickSelector += ", sl-button[href][data-confirm], sl-button[href][data-method], sl-button[href][data-remote]:not([disabled]), sl-button[href][data-disable-with], sl-button[href][data-disable]";
+    Rails.inputChangeSelector += ", sl-select[data-remote], sl-input[data-remote], sl-textarea[data-remote]";
+    Rails.formInputClickSelector += ", form:not([data-turbo=true]) sl-input[type=submit], form:not([data-turbo=true]) sl-input[type=image], form:not([data-turbo=true]) sl-button[type=submit], form:not([data-turbo=true]) sl-button:not([type]), sl-input[type=submit][form], sl-input[type=image][form], sl-button[type=submit][form], sl-button[form]:not([type])";
+    Rails.formDisableSelector += ", sl-input[data-disable-with]:enabled, sl-button[data-disable-with]:enabled, sl-textarea[data-disable-with]:enabled, sl-input[data-disable]:enabled, sl-button[data-disable]:enabled, sl-textarea[data-disable]:enabled";
+    Rails.formEnableSelector += ", sl-input[data-disable-with]:disabled, sl-button[data-disable-with]:disabled, sl-textarea[data-disable-with]:disabled, sl-input[data-disable]:disabled, sl-button[data-disable]:disabled, sl-textarea[data-disable]:disabled";
+    Rails.fileInputSelector += ", sl-input[name][type=file]:not([disabled])";
+    Rails.linkDisableSelector += ", sl-button[href][data-disable-with], sl-button[href][data-disable]";
+    Rails.buttonDisableSelector += ", sl-button[data-remote][data-disable-with], sl-button[data-remote][data-disable]";
+
+    Rails.start();
 
     // Register free font-awesome icons
     Shoelace.registerIconLibrary("fa-free", {

--- a/rails-js/index.js
+++ b/rails-js/index.js
@@ -36,7 +36,7 @@ export default class Teamshares {
   static deployed_app_sha = HEROKU_SLUG_COMMIT;
   static Rails = Rails;
 
-  static init (config = {}) {
+  static start (config = {}) {
     console.log("Initializing Teamshares JS");
 
     if (config.disableTurboSessionDrive) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3121,11 +3121,6 @@ ini@^1.3.5:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
-inputmask@^5.0.8:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/inputmask/-/inputmask-5.0.8.tgz#cd0f70b058c3291a0d4f27de25dbfc179c998bb4"
-  integrity sha512-1WcbyudPTXP1B28ozWWyFa6QRIUG4KiLoyR6LFHlpT4OfTzRqFfWgHFadNvRuMN1S9XNVz9CdNvCGjJi+uAMqQ==
-
 internal-slot@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.5.tgz#f2a2ee21f668f8627a4667f309dc0f4fb6674986"


### PR DESCRIPTION
## Ticket
[Notion](https://www.notion.so/teamshares/more-shared-JS-2a1c7f4e362746aa9dac9ea32ed37a7b)

## Description
* Updates `Teamshares.init()` to `Teamshares.start()` (in line with pattern used by Rails' JS libraries)
* Ideally individual apps shouldn't be responsible for initializing libraries declared in the shared `package.json`
  * @hotwired/turbo-rails
  * @rails/ujs
  * Also DRYs the initialization of Stimulus controllers
    * (I'd _hoped_ to be able to extract the `import { definitions } from "stimulus:./"` line out of individual apps, too, but unfortunately esbuild relies on the directory the file itself is in during its resolve phase to autodiscover the controllers)
* Now that `@rails/ujs` is required from within Teamshares, expose `Teamshares.Rails` so we can remove other explicit includes in individual apps (Daross and I ran into a weird issue debugging shoelace where there were multiple Rails objects initialized... this should avoid that handily)
* Remove InputMaskController (will be copied into the apps that need it)
  * There [was discussion](https://teamsharesinc.slack.com/archives/C02J8V2R70W/p1696277301575749) of input masking being an anti-pattern, and there's no need to force the apps not using it to install the external dependency.