### PR TITLE
Add Tailwind container query plugin

### DIFF
--- a/configs/tailwind.config.js
+++ b/configs/tailwind.config.js
@@ -48,6 +48,7 @@ const tailwindConfig = {
   plugins: [
     require("@tailwindcss/forms"),
     require("@tailwindcss/typography"),
+    require("@tailwindcss/container-queries"),
   ],
   theme: {
     extend: tokens,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "7.3.0",
     "@rails/ujs": "7.1.1",
+    "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "0.5.6",
     "@tailwindcss/typography": "0.5.10",
     "@teamshares/shoelace": "^1.3.0",
@@ -42,9 +43,9 @@
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-preset-env": "^9.1.2",
     "postcss-reporter": "^7.0.5",
-    "tailwindcss": "3.3.3",
     "stylelint": "^15.0.0",
-    "stylelint-config-sass-guidelines": "^10.0.0"
+    "stylelint-config-sass-guidelines": "^10.0.0",
+    "tailwindcss": "3.3.3"
   },
   "devDependencies": {
     "concurrently": "^8.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -609,6 +609,11 @@
   resolved "https://registry.yarnpkg.com/@shoelace-style/localize/-/localize-3.1.1.tgz#f5b96e35a9a8709aa46d1aaa2359069c0db71534"
   integrity sha512-NkM/hj3Js6yXCU9WxhsyxRUdyqUUUl/BSvIluUMptQteUWGOJaoyP1iMbOMqO544DYMzBfnoCw66ZHkGuTdKgA==
 
+"@tailwindcss/container-queries@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/container-queries/-/container-queries-0.1.1.tgz#9a759ce2cb8736a4c6a0cb93aeb740573a731974"
+  integrity sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==
+
 "@tailwindcss/forms@0.5.6":
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.5.6.tgz#29c6c2b032b363e0c5110efed1499867f6d7e868"


### PR DESCRIPTION
Quick PR to add support for container queries, which Tailwind added back in version 3.2. For more on the plugin, see https://github.com/tailwindlabs/tailwindcss-container-queries