### PR TITLE
Expose the git sha of the deployed app to JS

### DIFF
--- a/rails-js/index.js
+++ b/rails-js/index.js
@@ -33,6 +33,7 @@ const _getDeployContext = () => {
 export default class Teamshares {
   static env = _getEnvContext();
   static deploy_context = _getDeployContext();
+  static deployed_app_sha = HEROKU_SLUG_COMMIT;
 
   static init (railsObj = Rails) {
     console.log("Initializing Teamshares JS");


### PR DESCRIPTION
## Ticket
@rkcrisafi requested via Slack, to be able to set `version` key for [datadog RUM's config](https://docs.datadoghq.com/real_user_monitoring/browser/).

## Description
Exposes the deployed app's git SHA to JS via `Teamshares.deployed_app_sha`


> ## Release Reminder
> You'll need to push PRs to any consuming apps that need to _use_ these changes (after this PR is merged, `yarn upgrade @teamshares/design-system` in the consuming apps).
