### PR TITLE
Fix resolving node_modules from teamshares-rails JS

### DIFF
--- a/configs/esbuild.config.js
+++ b/configs/esbuild.config.js
@@ -61,6 +61,11 @@ const sharedConfig = {
   loader: {
     ".svg": "file",
   },
+
+  // Explicitly use working directory's node_modules, so we look *here* for teamshares-rails js imports
+  // (rather than looking in teamshares-rails + parents for a node_modules that doesn't exist if yarn was never run there)
+  nodePaths: [path.join(APP_ROOT, "node_modules")],
+
   define: {
     "process.env.HEROKU_APP_NAME": `"${process.env.HEROKU_APP_NAME || ""}"`,
     "process.env.RAILS_ENV": `"${process.env.RAILS_ENV || "development"}"`,

--- a/lib/teamshares-rails-path.js
+++ b/lib/teamshares-rails-path.js
@@ -3,7 +3,12 @@ const cachePath = "tmp/.cached-teamshares-rails-path";
 
 const getTeamsharesRailsPath = () => {
   try {
-    return fs.readFileSync(cachePath).toString();
+    const cachedPath = fs.readFileSync(cachePath).toString();
+
+    // NOTE: throws if path doesn't exist (e.g. gem has been updated)
+    fs.readdirSync(cachedPath);
+
+    return cachedPath;
   } catch (err) {
     const gemPath = require("child_process").execSync("bundle show teamshares_rails").toString().trim();
     fs.writeFileSync(cachePath, gemPath);


### PR DESCRIPTION
## Description
This resolves an esbuild issue `[ERROR] Could not resolve "@hotwired/stimulus"` when it tries to load a stimulus controller from teamshares-rails.