### PR TITLE
Fix: Un-hide ts-wrapper when :not(:defined)

### DIFF
--- a/scss/index.scss
+++ b/scss/index.scss
@@ -6,3 +6,10 @@
 
 // Include SharedUI (from tsRailsPath) + application (from APP_ROOT) component styles (enabled by postcss-easy-import's path)
 @import 'app/frontend/components/**/*.scss';  // stylelint-disable-line scss/at-import-partial-extension-blacklist
+
+// Override the FOUC solution in Shoelace theme, which causes the (undefined) ts-wrapper to be hidden forever
+// TODO: Eventually we may want to actually register that ts-wrapper component, especially if we want it to do something,
+// such as give us analytics on ViewComponent usage
+ts-wrapper:not(:defined) {
+  visibility: visible;
+}


### PR DESCRIPTION
## Description

Fix for an issue OS was seeing where the navigation was being hidden upon updating to the latest version of teamshares_rails. It was due to the new `ViewComponent` wrapper, which adds an empty `ts-wrapper` tag around the component. That tag isn't registered with the CustomElementRegistry, and therefore gets hidden by Shoelace's `:not(:defined)` rule for preventing FOUC.


> ## Release Reminder
> You'll need to push PRs to any consuming apps that need to _use_ these changes (after this PR is merged, `yarn upgrade @teamshares/design-system` in the consuming apps).
