### PR TITLE
[Hotfix] Display: contents for ts-wrapper

### DIFF
--- a/scss/index.scss
+++ b/scss/index.scss
@@ -13,3 +13,8 @@
 ts-wrapper:not(:defined) {
   visibility: visible;
 }
+
+// Make the wrapper's children to appear as if they were direct children of the wrapper's parent, ignoring the wrapper itself.
+ts-wrapper {
+  display: contents;
+}

--- a/scss/index.scss
+++ b/scss/index.scss
@@ -18,3 +18,15 @@ ts-wrapper:not(:defined) {
 ts-wrapper {
   display: contents;
 }
+
+// EXPERIMENTAL: Rules that have to do with the order of the elements need to be passed along via a :has selector, and that rule needs to be removed from the child
+// Note this this only one of such exceptions. The others will need to be added as we find them.
+// TODO: Need to look at just pulling all or some classes off the top-level div in wrapped components and applying those classes to the wrapper
+// or not using the wrapper element at all, and applying the classes to the top level div of the VC directly
+ts-wrapper:has(.last\:border-b-0:last-child) {
+  @apply last:border-b-0;
+}
+
+ts-wrapper .last\:border-b-0:last-child {
+  border-bottom-width: initial;
+}


### PR DESCRIPTION
## Ticket
[Linear](https://linear.app/teamshares/issue/PLA-58/hotfix-display-for-ts-wrapper-causing-layout-problems)

## Description
The ts-wrapper for our new ViewComponents encapsulation causes issues with block-level elements, because it's a new block context. So, for example, it doesn't automatically have full width if the child element has .w-full.

A more complex problem comes with rules like last:border-bottom-0, which removes the bottom border for the last child. Since all the VCs are now wrapped with ts-wrapper, they are always the last child, and the ts-wrapper would need to have that rule applied instead of the wrapped VC.

## Screenshots (if relevant)

Bug:
<img width="601" alt="image" src="https://github.com/teamshares/design-system/assets/1148607/830f483f-5d82-4a5a-a621-7db69002e71f">

Partial fix (still has extra border at bottom, because it's difficult to get the wrapper to apply the correct rule logic):
<img width="591" alt="image" src="https://github.com/teamshares/design-system/assets/1148607/cedee7ff-3976-4952-a38f-40410e90962f">


> ## Release Reminder
> You'll need to push PRs to any consuming apps that need to _use_ these changes (after this PR is merged, `yarn upgrade @teamshares/design-system` in the consuming apps).
