### PR TITLE
[Hotfix]: @apply "circular dependency" error

### DIFF
--- a/scss/index.scss
+++ b/scss/index.scss
@@ -23,8 +23,8 @@ ts-wrapper {
 // Note this this only one of such exceptions. The others will need to be added as we find them.
 // TODO: Need to look at just pulling all or some classes off the top-level div in wrapped components and applying those classes to the wrapper
 // or not using the wrapper element at all, and applying the classes to the top level div of the VC directly
-ts-wrapper:has(.last\:border-b-0:last-child) {
-  @apply last:border-b-0;
+ts-wrapper:has(.last\:border-b-0:last-child):last-child {
+  border-bottom-width: 0;
 }
 
 ts-wrapper .last\:border-b-0:last-child {


### PR DESCRIPTION
Using @apply causes a "circular dependency" error for tailwind

## Ticket
[Linear](https://linear.app/teamshares/issue/PLA-58/hotfix-display-for-ts-wrapper-causing-layout-problems)