### PR TITLE
Pulled in @teamshares/shoelace 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "0.5.7",
     "@tailwindcss/typography": "0.5.10",
-    "@teamshares/shoelace": "^2.0.0",
+    "@teamshares/shoelace": "2.0.1",
     "cssnano": "^6.0.1",
     "esbuild": "^0.19.2",
     "esbuild-plugin-copy": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -723,10 +723,10 @@
     lodash.merge "^4.6.2"
     postcss-selector-parser "6.0.10"
 
-"@teamshares/shoelace@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@teamshares/shoelace/-/shoelace-2.0.0.tgz#0e3ca32f97e3e9726276e040ae27342c12175f91"
-  integrity sha512-klprEiJxs2aMCcvCt1CMfNmSMJ6BgOLM+JC1TiUip9w+L36fEACWhgmsRT0sdJcy/mjwi9QBZgtdjMvXDL0aCw==
+"@teamshares/shoelace@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@teamshares/shoelace/-/shoelace-2.0.1.tgz#cb1deaa16d4a388ff3366780cb66464a68dd0f52"
+  integrity sha512-kNHkCSFWWLoj+mM/7j+K2ZKezy+2UDGD3Z9ftJ9S1Re5KxBYYVwWhjjVvmU7ovxntiUAspOwUltrobKphQt+3Q==
   dependencies:
     "@ctrl/tinycolor" "^4.0.2"
     "@floating-ui/dom" "^1.5.3"


### PR DESCRIPTION
## Ticket
This version adds a fix for [Linear](https://linear.app/teamshares/issue/PLA-85/cant-click-items-in-sl-details-drawer-header), in which links in the header of `sl-details` weren't clickable.

> ## Release Reminder
> You'll need to push PRs to any consuming apps that need to _use_ these changes (after this PR is merged, `yarn upgrade @teamshares/design-system` in the consuming apps).
