### PR TITLE
Fix PLA-83: rearrange PostCSS plugins

### DIFF
--- a/configs/postcss.config.js
+++ b/configs/postcss.config.js
@@ -25,9 +25,9 @@ const configBuilder = (tailwindConfigTransformer = defaultConfigTransformer) => 
     parser: "postcss-scss",
     plugins: [
       require("postcss-easy-import")({ path: [tsRailsPath, APP_ROOT], prefix: "_", extensions: [".css", ".scss"], plugins: [
-        require("tailwindcss/nesting"),
         prefixComponentClasses,
       ] }),
+      require("tailwindcss/nesting"),
       require("tailwindcss")(tailwindConfig),
       require("postcss-flexbugs-fixes"),
       require("postcss-preset-env")({


### PR DESCRIPTION
## Ticket
[Linear](https://linear.app/teamshares/issue/PLA-83/nested-scss-throws-error-in-cash-account)

## Description
Bug: SCSS nesting is not compiled in several files in /frontend/stylesheets/*. This throws a few errors when initially running bin/dev, but also causes some frontend issues where the final CSS is not correctly applied.

This PR re-orders the PostCSS plugins, which hopefully resolves the issue.

> ## Release Reminder
> You'll need to push PRs to any consuming apps that need to _use_ these changes (after this PR is merged, `yarn upgrade @teamshares/design-system` in the consuming apps).
