### PR TITLE
Hotfix - Revert previous postCSS fix

### DIFF
--- a/configs/postcss.config.js
+++ b/configs/postcss.config.js
@@ -25,9 +25,9 @@ const configBuilder = (tailwindConfigTransformer = defaultConfigTransformer) => 
     parser: "postcss-scss",
     plugins: [
       require("postcss-easy-import")({ path: [tsRailsPath, APP_ROOT], prefix: "_", extensions: [".css", ".scss"], plugins: [
+        require("tailwindcss/nesting"),
         prefixComponentClasses,
       ] }),
-      require("tailwindcss/nesting"),
       require("tailwindcss")(tailwindConfig),
       require("postcss-flexbugs-fixes"),
       require("postcss-preset-env")({


### PR DESCRIPTION
A previous update, https://github.com/teamshares/design-system/commit/59dfd4bb7026b711f9473d0065554d0f2629ed7e, which fixed an issue with PostCSS not wrapping styles properly, is now causing a much worse problem in prod:

<img width="326" alt="image" src="https://github.com/teamshares/design-system/assets/1148607/1cf3f90c-d986-4d5e-a48f-3128c8d4d32d">

After fix: 
<img width="402" alt="image" src="https://github.com/teamshares/design-system/assets/1148607/0372888f-c64a-4da8-87e9-a0465773d900">


## Description


## Screenshots (if relevant)


> ## Release Reminder
> You'll need to push PRs to any consuming apps that need to _use_ these changes (after this PR is merged, `yarn upgrade @teamshares/design-system` in the consuming apps).
