### PR TITLE
New PostCSS plugin to clean up the incorrectly generated class names

### DIFF
--- a/configs/postcss.config.js
+++ b/configs/postcss.config.js
@@ -24,10 +24,15 @@ const configBuilder = (tailwindConfigTransformer = defaultConfigTransformer) => 
   const postcssConfig = {
     parser: "postcss-scss",
     plugins: [
-      require("postcss-easy-import")({ path: [tsRailsPath, APP_ROOT], prefix: "_", extensions: [".css", ".scss"], plugins: [
-        require("tailwindcss/nesting"),
-        prefixComponentClasses,
-      ] }),
+      require("postcss-easy-import")({ 
+        path: [tsRailsPath, APP_ROOT], 
+        prefix: "_", 
+        extensions: [".css", ".scss"],
+        plugins: [
+          prefixComponentClasses,
+        ]
+      }),
+      require("tailwindcss/nesting"),
       require("tailwindcss")(tailwindConfig),
       require("postcss-flexbugs-fixes"),
       require("postcss-preset-env")({
@@ -39,6 +44,7 @@ const configBuilder = (tailwindConfigTransformer = defaultConfigTransformer) => 
         },
         stage: 3,
       }),
+      require("./postcss/cleanup-component-classes.js"),
       isProd ? require("cssnano")({ preset: "default" }) : null,
       require("postcss-reporter")({ clearReportedMessages: true }),
     ].filter(Boolean),

--- a/configs/postcss/cleanup-component-classes.js
+++ b/configs/postcss/cleanup-component-classes.js
@@ -1,0 +1,66 @@
+/** 
+ * This PosCSS plugin cleans up after the cases in which Tailwind's nesting 
+ * incorrectly doubles our generated component classes.
+ * See the test code below for examples.
+ */
+function cleanupSelector(selector) {
+  // Match anything in the selector with the pattern `.c-foo--bar-qux--baz`
+  let pattern = selector.match(/\.c-[^ .]*--[^ .]*/);
+  if (pattern) {
+    let before = selector.toString();
+    let firstIndex = selector.indexOf(pattern);
+    // Create a regex object from the above matched pattern, e.g. `/\.c\-foo\-\-bar\-qux\-\-baz/g`
+    let regex = new RegExp(pattern[0].replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&'), "g");
+    // Keep only the first instance of that pattern in the selector
+    let after = selector.replace(regex, (match, index) => index === firstIndex ? match : "");
+    selector = after.split(' ').filter(Boolean).join(' ');
+    if (selector !== before) {
+      console.log(` ─╮ ${before}`);
+      console.log(`  ╰→${selector}`);
+    }
+  }
+  return selector;
+}
+
+/** Test code for the method above */
+/**
+// How it starts after Tailwind has had its way with application.css
+const input = [
+  ".c-shared-ui--navigation--app-switcher",
+  ".c-shared-ui--navigation--app-switcher .c-shared-ui--navigation--app-switcher .app-switcher-nav-items .c-shared-ui--navigation--app-switcher a:hover",
+  ".c-shared-ui--demo",
+  ".c-shared-ui--navigation--app-switcher .c-shared-ui--navigation--app-switcher .app-switcher-nav-items .c-shared-ui--navigation--app-switcher a:hover .c-shared-ui--navigation--app-switcher .app-icon",
+  ".c-foo--bar-qux--baz",
+  ".ts-drawer.c-foo--bar-qux--baz .c-foo--bar-qux--baz sl-card::part(base) .ts-drawer__links a",
+  ".c-foo--bar-qux--baz sl-card .c-foo--bar-qux--baz sl-icon-button"
+];
+// How it was supposed to look
+const output = [
+  ".c-shared-ui--navigation--app-switcher",
+  ".c-shared-ui--navigation--app-switcher .app-switcher-nav-items a:hover",
+  ".c-shared-ui--demo",
+  ".c-shared-ui--navigation--app-switcher .app-switcher-nav-items a:hover .app-icon",
+  ".c-foo--bar-qux--baz",
+  ".ts-drawer.c-foo--bar-qux--baz sl-card::part(base) .ts-drawer__links a"
+  ".c-foo--bar-qux--baz sl-card sl-icon-button"
+];
+function simplifySelectors(inputArray) {
+  return inputArray.map(cleanupSelector);
+}
+// This should be equal to output above
+console.log(simplifySelectors(input));
+*/
+
+const cleanupComponentClasses = () => {
+  return {
+    postcssPlugin: "cleanup-component-classes",
+    Once (root, result) {
+      root.walkRules(rule => {
+        rule.selector = cleanupSelector(rule.selector);
+      });
+    },
+  };
+}
+cleanupComponentClasses.postcss = true;
+
+module.exports = cleanupComponentClasses;

--- a/configs/postcss/prefix-component-classes.js
+++ b/configs/postcss/prefix-component-classes.js
@@ -1,49 +1,32 @@
-const postcss = require('postcss');
-const prefixComponentClasses = postcss.plugin('prefix-component-classes', () => {
-    return (root, result) => {
-      const matches = result.opts.from.match(/frontend\/components\/?(.*)\/[^/]+?.s?css$/);
+const prefixComponentClasses = () => {
+  return {
+    postcssPlugin: "prefix-component-classes",
+    Once (root, result) {
+      const matches = result.result.opts.from.match(/frontend\/components\/?(.*)\/[^/]+?.s?css$/);
 
       // Do not transform CSS files from outside of the components folder
       if (!matches) return;
 
       const identifier = matches[1].replaceAll("/", "--").replaceAll("_", "-");
+      // console.log('================= prefixing component classes for', identifier);
 
       root.walkRules(rule => {
-        // console.log(`[${identifier}] ${rule.selector}`);
+        // console.log(` ─╮ ${rule.selector}`);
         // If the selector is our special `._base` rule, apply those styles directly to the generated class itself
         if (rule.selector == "._base") {
           rule.selector = `.c-${identifier}`;
         } else {
           rule.selector = `.c-${identifier} ${rule.selector}`;
         }
+        // console.log(`  ╰→${rule.selector}`);
       });
-    };
-});
+    },
+  };
+}
+prefixComponentClasses.postcss = true;
 
-// NOTE: in *theory* the code below should switch to above plugin from v7 to v8...
-// See migrations guide: https://evilmartians.com/chronicles/postcss-8-plugin-migration.
+module.exports = prefixComponentClasses;
 
-// Unfortunately, it starts throwing "CssSyntaxError: postcss-easy-import: <file>: Unknown word"
-// errors for // comments
 
-// const prefixComponentClasses = () => {
-//     return {
-//       postcssPlugin: "prefix-component-classes",
-//       Once (root, result) {
-//         const matches = result.opts.from.match(/frontend\/components\/?(.*)\/[^/]+?.s?css$/);
 
-//         // Do not transform CSS files from outside of the components folder
-//         if (!matches) return;
 
-//         const identifier = matches[1].replaceAll("/", "--").replaceAll("_", "-");
-
-//         root.walkRules(rule => {
-//           console.log(`[${identifier}] ${rule.selector}`);
-//           rule.selector = `.c-${identifier} ${rule.selector}`;
-//         });
-//       },
-//     };
-// }
-// prefixComponentClasses.postcss = true;
-
-module.exports = prefixComponentClasses

--- a/scss/index.scss
+++ b/scss/index.scss
@@ -1,8 +1,8 @@
-// @teamshares/design-system
-@import 'without_shoelace'; // NOTE: broken up so public-website can avoid importing shoelace in its entirety
+/* @teamshares/design-system */
+@import 'without_shoelace'; /* NOTE: broken up so public-website can avoid importing shoelace in its entirety */
 
 @import '@teamshares/shoelace/dist/themes/light';
 @import '@teamshares/shoelace/dist/styles/index';
 
-// Include SharedUI (from tsRailsPath) + application (from APP_ROOT) component styles (enabled by postcss-easy-import's path)
-@import 'app/frontend/components/**/*.scss';  // stylelint-disable-line scss/at-import-partial-extension-blacklist
+/* Include SharedUI (from tsRailsPath) + application (from APP_ROOT) component styles (enabled by postcss-easy-import's path) */
+@import 'app/frontend/components/**/*.scss';  /* stylelint-disable-line scss/at-import-partial-extension-blacklist */


### PR DESCRIPTION
## Ticket
[Linear](https://linear.app/teamshares/issue/PLA-190/new-postcss-plugin-to-clean-up-classes)

## Description
This puts back our previous fix for incorrect nesting in PostCSS, but also adds a new plugin that un-does the style name duplication that Tailwind was doing.

Output from the CSS generation step (before -> after for each matching rule):
```
 ─╮ .c-shared-ui--navigation--app-switcher .c-shared-ui--navigation--app-switcher sl-dropdown.app-switcher-dropdown::part(panel)
  ╰→.c-shared-ui--navigation--app-switcher sl-dropdown.app-switcher-dropdown::part(panel)
 ─╮ .c-shared-ui--navigation--app-switcher .c-shared-ui--navigation--app-switcher sl-button.app-switcher-dropdown-trigger::part(base)
  ╰→.c-shared-ui--navigation--app-switcher sl-button.app-switcher-dropdown-trigger::part(base)
 ─╮ .c-shared-ui--navigation--app-switcher .c-shared-ui--navigation--app-switcher sl-button.app-switcher-dropdown-trigger::part(label)
  ╰→.c-shared-ui--navigation--app-switcher sl-button.app-switcher-dropdown-trigger::part(label)
 ─╮ .c-shared-ui--navigation--app-switcher .c-shared-ui--navigation--app-switcher sl-button.app-switcher-dropdown-trigger::part(caret)
  ╰→.c-shared-ui--navigation--app-switcher sl-button.app-switcher-dropdown-trigger::part(caret)
 ─╮ .c-shared-ui--navigation--app-switcher sl-button.app-switcher-dropdown-trigger .c-shared-ui--navigation--app-switcher .dropdown-open::part(base)
  ╰→.c-shared-ui--navigation--app-switcher sl-button.app-switcher-dropdown-trigger .dropdown-open::part(base)
 ─╮ .c-shared-ui--navigation--app-switcher .app-switcher-nav-items .c-shared-ui--navigation--app-switcher a
  ╰→.c-shared-ui--navigation--app-switcher .app-switcher-nav-items a
 ─╮ .c-shared-ui--navigation--app-switcher .c-shared-ui--navigation--app-switcher .app-switcher-nav-items .c-shared-ui--navigation--app-switcher a:hover
  ╰→.c-shared-ui--navigation--app-switcher .app-switcher-nav-items a:hover
 ─╮ .c-shared-ui--navigation--app-switcher .c-shared-ui--navigation--app-switcher .app-switcher-nav-items .c-shared-ui--navigation--app-switcher a:hover .c-shared-ui--navigation--app-switcher .app-icon
  ╰→.c-shared-ui--navigation--app-switcher .app-switcher-nav-items a:hover .app-icon
 ─╮ .c-shared-ui--navigation--app-switcher .app-switcher-nav-items .c-shared-ui--navigation--app-switcher a .c-shared-ui--navigation--app-switcher .app-icon
  ╰→.c-shared-ui--navigation--app-switcher .app-switcher-nav-items a .app-icon
 ─╮ .c-shared-ui--navigation--app-switcher .app-switcher-nav-items .c-shared-ui--navigation--app-switcher .app-switcher-nav-item-main-column
  ╰→.c-shared-ui--navigation--app-switcher .app-switcher-nav-items .app-switcher-nav-item-main-column
 ─╮ .c-shared-ui--navigation--app-switcher .app-switcher-nav-items .c-shared-ui--navigation--app-switcher .app-switcher-app-name
  ╰→.c-shared-ui--navigation--app-switcher .app-switcher-nav-items .app-switcher-app-name
 ─╮ .c-shared-ui--navigation--app-switcher .app-switcher-nav-items a.selected .c-shared-ui--navigation--app-switcher .app-icon
  ╰→.c-shared-ui--navigation--app-switcher .app-switcher-nav-items a.selected .app-icon
 ─╮ .c-foo--bar-qux--baz sl-card .c-foo--bar-qux--baz [slot='header']
  ╰→.c-foo--bar-qux--baz sl-card [slot='header']
 ─╮ .c-foo--bar-qux--baz sl-card .c-foo--bar-qux--baz .inner
  ╰→.c-foo--bar-qux--baz sl-card .inner
 ─╮ .ts-drawer.c-foo--bar-qux--baz .c-foo--bar-qux--baz sl-card::part(base) .ts-drawer__links a
  ╰→.ts-drawer.c-foo--bar-qux--baz sl-card::part(base) .ts-drawer__links a
 ─╮ .c-foo--bar-qux--baz .c-foo--bar-qux--baz sl-card::part(base)
  ╰→.c-foo--bar-qux--baz sl-card::part(base)
 ─╮ .c-foo--bar-qux--baz sl-card .c-foo--bar-qux--baz sl-icon-button
  ╰→.c-foo--bar-qux--baz sl-card sl-icon-button
```


> ## Release Reminder
> You'll need to push PRs to any consuming apps that need to _use_ these changes (after this PR is merged, `yarn upgrade @teamshares/design-system` in the consuming apps).
