### PR TITLE
Add link styles to typography.scss

### DIFF
--- a/scss/core-includes/_typography.scss
+++ b/scss/core-includes/_typography.scss
@@ -74,4 +74,26 @@
   .ts-text-error {
     @apply text-red-700;
   }
+
+  .ts-text-link {
+    @apply text-blue-600;
+    @apply underline decoration-1 underline-offset-4;
+    @apply transition-all duration-300 ease-in-out;
+  }
+  
+  .ts-text-link:hover {
+    @apply text-blue-700;
+    @apply decoration-transparent;
+  }
+  
+  .ts-text-link-light {
+    @apply text-blue-300;
+    @apply underline decoration-1 underline-offset-4;
+    @apply transition-all duration-300 ease-in-out;
+  }
+  
+  .ts-text-link-light:hover {
+    @apply text-blue-200;
+    @apply decoration-transparent;
+  }
 }


### PR DESCRIPTION
## Ticket
[PLA-71](https://linear.app/teamshares/issue/PLA-71/the-unauthorized-page-os-only-users-attempt-to-access-a-cash-url)


## Description
- Adding classes for a `ts-text-link` style, for immediate use in the linked ticket, as well as for broader use across our products
- Link styling matches style already implemented in [`<sl-breadcrumb-item>`](https://design.teamshares.com/components/breadcrumb-item) and documented on the doc site under ["Linked text"](https://design.teamshares.com/tokens/ts-colors#link-text)
- Design team is agreed on use as our main link style.

## Screenshots (if relevant)


> ## Release Reminder
> You'll need to push PRs to any consuming apps that need to _use_ these changes (after this PR is merged, `yarn upgrade @teamshares/design-system` in the consuming apps).
