### PR TITLE
Updating to grab Shoelace fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "0.5.7",
     "@tailwindcss/typography": "0.5.10",
-    "@teamshares/shoelace": "2.0.1",
+    "@teamshares/shoelace": "^2.0.2",
     "cli-color": "^2.0.3",
     "cssnano": "^6.0.1",
     "esbuild": "^0.19.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -723,10 +723,10 @@
     lodash.merge "^4.6.2"
     postcss-selector-parser "6.0.10"
 
-"@teamshares/shoelace@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@teamshares/shoelace/-/shoelace-2.0.1.tgz#cb1deaa16d4a388ff3366780cb66464a68dd0f52"
-  integrity sha512-kNHkCSFWWLoj+mM/7j+K2ZKezy+2UDGD3Z9ftJ9S1Re5KxBYYVwWhjjVvmU7ovxntiUAspOwUltrobKphQt+3Q==
+"@teamshares/shoelace@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@teamshares/shoelace/-/shoelace-2.0.2.tgz#5dbf384c2596705aa43aee24b6724823d6cef0f6"
+  integrity sha512-cDvaNxYLaWbpxalDIljTG34T841Pzkp2najZHubrzRKoxzOtVbKS2dlRwgOCYj0TAuNAF/gcmplfa7DMMIFqCQ==
   dependencies:
     "@ctrl/tinycolor" "^4.0.2"
     "@floating-ui/dom" "^1.5.3"


### PR DESCRIPTION
## Description

Patch update to Shoelace, to grab Spinner fix by @slhinyc for @andrewdeitrick.

## Screenshots (if relevant)


> ## Release Reminder
> You'll need to push PRs to any consuming apps that need to _use_ these changes (after this PR is merged, `yarn upgrade @teamshares/design-system` in the consuming apps).
