### PR TITLE
Add default text color and font smoothing decs to <body>

### DIFF
--- a/scss/core-includes/_teamshares.scss
+++ b/scss/core-includes/_teamshares.scss
@@ -29,7 +29,7 @@ body {
   font-size: 1rem;
   letter-spacing: -0.01rem;
   line-height: 1.75rem;
-  @apply font-normal;
+  @apply font-normal ts-text-default antialiased;
 }
 
 a {


### PR DESCRIPTION
[PLA-246](https://linear.app/teamshares/issue/PLA-246/fix-antialiasing-in-our-apps) and [PLA-236](https://linear.app/teamshares/issue/PLA-236/adjust-app-stylesheets-so-that-text-defaults-to-ts-text-default)

- Super small change to `<body>` styles to...
  - Set default text color to `ts-text-default` (to prevent some text appearing as pure black `#000` instead of our palette `gray-900`) 
  - Set font-smoothing to `antialiased` to prevent text appearing extra bold because of the way it's antialised (affects Mac users only)
- See Linear issues linked above for more details  
- Also see SS comparisons below of OS and FP
_On left, local, with antialiasing & text color applied; On right, staging_

<img width="2556" alt="antialiasing_comparison_OS" src="https://github.com/teamshares/design-system/assets/203228/4cd9fe9c-43aa-4a92-a8b6-532a0d7ad7bf">
<img width="2560" alt="antialiasing_comparison_FP" src="https://github.com/teamshares/design-system/assets/203228/d8b44b20-0ede-43e5-9108-561519182e94">