### PR TITLE
Remove caching in teamshares-rails-path

### DIFF
--- a/lib/teamshares-rails-path.js
+++ b/lib/teamshares-rails-path.js
@@ -1,20 +1,7 @@
-const fs = require("fs");
-const cachePath = "tmp/.cached-teamshares-rails-path";
+// Note: previously we cached the path to the teamshares_rails gem, but that introduced
+// versioning bugs since bundler is appending the SHA to the path on disk.
 
-const getTeamsharesRailsPath = () => {
-  try {
-    const cachedPath = fs.readFileSync(cachePath).toString();
-
-    // NOTE: throws if path doesn't exist (e.g. gem has been updated)
-    fs.readdirSync(cachedPath);
-
-    return cachedPath;
-  } catch (err) {
-    const gemPath = require("child_process").execSync("bundle show teamshares_rails").toString().trim();
-    fs.writeFileSync(cachePath, gemPath);
-    return gemPath;
-  }
-};
+const getTeamsharesRailsPath = () => require("child_process").execSync("bundle show teamshares_rails").toString().trim();
 
 module.exports = {
   getTeamsharesRailsPath,


### PR DESCRIPTION
As discussed w/ Platform team, this trades off a _slight_ performance reduction in order to fix confusion/bugs caused by caching bundler's output, since it appends the git SHA to the path of the gem on disk.