### PR TITLE
temporarily add health insurance stimulus conotrollers

### DIFF
--- a/configs/esbuild.config.js
+++ b/configs/esbuild.config.js
@@ -78,6 +78,7 @@ const sharedConfig = {
     EsbuildPluginResolve({
       "@teamshares-rails": path.join(tsRailsPath, "app/frontend"),
       "@app": path.join(APP_ROOT, "app/frontend"),
+      "@health-engine": path.join(APP_ROOT, "health_insurance/app/frontend"),
     }),
     importGlobPlugin.default(),
     copy({

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/teamshares/design-system.git"
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "files": [
     "scss/**/*.scss",

--- a/rails-js/controllers/index.js
+++ b/rails-js/controllers/index.js
@@ -7,6 +7,10 @@ const sharedComponentControllersGlob = require("@teamshares-rails/components/**/
 const appComponentControllersGlob = require("@app/components/**/controller.js");
 const appControllersGlob = require("@app/javascript/controllers/**/*_controller.js");
 
+// TODO: this is hardcoding for the health insurance onboarding engine - remove when app is extracted from OS
+const tempHealthEngineComponentControllersGlob = require("@health-engine/components/**/controller.js");
+const tempHealthEngineControllersGlob = require("@health-engine/javascript/controllers/**/*_controller.js");
+
 // NOTE: we could move the shared stimulus controllers in design-system back into teamshares_rails too,
 // but we haven't figured out how to manage any JS dependencies that might be needed by those controllers.
 // const sharedControllersGlob = require("@app/javascript/controllers/**.js");
@@ -37,9 +41,11 @@ const registerStimulusControllers = () => {
 
   // Auto-load all app controllers
   _registerControllersFromGlob(application, appControllersGlob, pathToStimulusControllerIdentifier);
+  _registerControllersFromGlob(application, tempHealthEngineControllersGlob, pathToStimulusControllerIdentifier);
 
   // Auto-load all app component controllers
   _registerControllersFromGlob(application, appComponentControllersGlob, pathToComponentControllerIdentifier);
+  _registerControllersFromGlob(application, tempHealthEngineComponentControllersGlob, pathToComponentControllerIdentifier);
 
   // Configure Stimulus development experience
   application.warnings = true;


### PR DESCRIPTION
## Ticket
Related to [Notion](https://linear.app/teamshares/issue/PRO-221/presidents-can-set-lowest-wage-and-modelset-insurance-contributions) ticket

## Description
Register `health-insurance` stimulus controllers

> ## Release Reminder
> You'll need to push PRs to any consuming apps that need to _use_ these changes (after this PR is merged, `yarn upgrade @teamshares/design-system` in the consuming apps).
