### PR TITLE
New release 1.3.0, to bump Shoelace to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## UNRELEASED
 * Add change description here
 
+## 1.3.0
+* Updates to error styles for Shoelace forms wrapped with Simple Form; update `<body>` decs to remove `letter-spacing` and update `line-height` to match default for `body-1`
+* Bump to Shoelace 2.1.0
+
 ## 1.2.2
 * Add temp support for health insurance engine's view components SCSS [@kdonovan]
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/teamshares/design-system.git"
   },
-  "version": "1.2.2",
+  "version": "1.3.0",
   "private": true,
   "files": [
     "scss/**/*.scss",
@@ -26,7 +26,7 @@
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "0.5.7",
     "@tailwindcss/typography": "0.5.12",
-    "@teamshares/shoelace": "^2.0.2",
+    "@teamshares/shoelace": "^2.1.0",
     "cli-color": "^2.0.3",
     "cssnano": "^6.0.1",
     "esbuild": "^0.20.0",

--- a/scss/core-includes/_forms.scss
+++ b/scss/core-includes/_forms.scss
@@ -219,37 +219,61 @@
 }
 
 // SimpleForm + Shoelace error styling
+
+// Add red-600 border for invalid input borders
 sl-input[data-user-invalid]::part(base),
 sl-select[data-user-invalid]::part(combobox),
 sl-checkbox[data-user-invalid]::part(control),
-sl-textarea[data-user-invalid]::part(textarea) {
-  @apply border-red-700;
+sl-textarea[data-user-invalid]::part(base) {
+  @apply border-red-600;
 }
 
-[data-user-invalid]::part(form-control-help-text) {
-  @apply text-red-700;
+// When an invalid input has focus, add an error focus ring
+sl-input:focus-within[data-user-invalid]::part(base),
+sl-select:focus-within[data-user-invalid]::part(combobox),
+sl-textarea:focus-within[data-user-invalid]::part(base) {
+  @apply border-red-600;
+  @apply ring-4 ring-red-400 ring-offset-0;
 }
 
-[data-user-invalid]::part(form-control-label) {
-  @apply border border-red-700;
+// sl-checkbox needs outline instead of box-shadow override
+sl-checkbox:focus-within[data-user-invalid]::part(control) {
+  @apply border-red-600;
+  @apply outline-red-600/50;
 }
 
 
+// Applies the same error styles based on 'field_with_errors' class rather than [data-user-invalid]
 .field_with_errors {
-  @apply text-red-700;
-
+  // Add red-600 border for input borders
   sl-input::part(base),
   sl-select::part(combobox),
   sl-checkbox::part(control),
-  sl-textarea::part(textarea) {
-    @apply border-red-700;
+  sl-textarea::part(base) {
+    @apply border-red-600;
   }
 
-  ::part(form-control-help-text), .ts-input__help {
+  // When an invalid input has focus, add an error focus ring
+  sl-input:focus-within::part(base),
+  sl-select:focus-within::part(combobox),
+  sl-textarea:focus-within::part(base) {
+    @apply border-red-600;
+    @apply ring-4 ring-red-400 ring-offset-0;
+  }
+
+  // sl-checkbox needs outline instead of box-shadow override
+  sl-checkbox:focus-within::part(control) {
+    @apply border-red-600;
+    @apply outline-red-600/50;
+  }
+
+  .error.ts-input__help {
+    @apply mt-2;
+    @apply ts-body-2;
     @apply text-red-700;
-  }
 
-  ::part(form-control-label) {
-    @apply border border-red-700;
+    &:first-letter  {
+      text-transform: capitalize;
+    }    
   }
 }

--- a/scss/core-includes/_teamshares.scss
+++ b/scss/core-includes/_teamshares.scss
@@ -27,8 +27,7 @@ html {
 body {
   font-family: theme('fontFamily.sans');
   font-size: 1rem;
-  letter-spacing: -0.01rem;
-  line-height: 1.75rem;
+  line-height: 1.5rem;
   @apply font-normal ts-text-default antialiased;;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,10 +728,10 @@
     lodash.merge "^4.6.2"
     postcss-selector-parser "6.0.10"
 
-"@teamshares/shoelace@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@teamshares/shoelace/-/shoelace-2.0.2.tgz#5dbf384c2596705aa43aee24b6724823d6cef0f6"
-  integrity sha512-cDvaNxYLaWbpxalDIljTG34T841Pzkp2najZHubrzRKoxzOtVbKS2dlRwgOCYj0TAuNAF/gcmplfa7DMMIFqCQ==
+"@teamshares/shoelace@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@teamshares/shoelace/-/shoelace-2.1.0.tgz#6990d493d1fb66bb60161e137a3f1e5d7ee2c5f3"
+  integrity sha512-Xn2z42KBq+e+qeR7k46tpZWIVBgSRR4NSSCjbhbBeUoUe8Oj6tDfpPpUjIUa4lL46idfOZcW1KcTXF2nZ1QoRA==
   dependencies:
     "@ctrl/tinycolor" "^4.0.2"
     "@floating-ui/dom" "^1.5.3"


### PR DESCRIPTION
### What's in this PR
- Updates to form error styles for `sl-` form components wrapped in simple form
- Delete some style decs applied to `body`
  - While testing these changes locally in `teamshares-rails`, I noticed that we have `letter-spacing` and `line-height` decs on `body` here that don't match the default `letter-spacing` and `line-height` we have on `ts-body-1`. This was creating misalignment of form elements due to the line-height & also applying the wrong letter-spacing for text this size. 
  - Tested this change in `os-app` and `cash-account-app` and everything looks as we want it to. There are slight changes that are visible due to this line-height & letter-spacing update, but we want these changes.
