### PR TITLE
Bump to 1.4.2 + changelog.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## UNRELEASED
 * Add change description here
 
+## 1.4.2
+* Patch fix to bump `design-system` to a bew version, as the previous version bumped Shoelace but missed bumping `design-system` itself
+* **No dependencies**. This release is okay to merge without `teamshares-rails`
+
 ## 1.4.1
 * Bump to Shoelace 2.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 * Add change description here
 
 ## 1.4.2
-* Patch fix to bump `design-system` to a bew version, as the previous version bumped Shoelace but missed bumping `design-system` itself
-* **No dependencies**. This release is okay to merge without `teamshares-rails`
+* Patch fix to bump `design-system` to a new version, as the previous version bumped Shoelace but missed bumping `design-system` itself
+* **Okay to merge** This release is okay to merge without `teamshares-rails`
 
 ## 1.4.1
 * Bump to Shoelace 2.2.1

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/teamshares/design-system.git"
   },
-  "version": "1.4.0",
+  "version": "1.4.2",
   "private": true,
   "files": [
     "scss/**/*.scss",


### PR DESCRIPTION
## 1.4.2
* Patch fix to bump `design-system` to a new version, as the previous version bumped Shoelace but missed bumping `design-system` itself
* Also testing whether changelog notes will display in Renovate PR
* **✅ Okay to merge** — This release is okay to merge without `teamshares-rails`
