### PR TITLE
Remove leftover traces that prevent css from building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## UNRELEASED
 * Add change description here
 
+## 1.6.1
+* [Bugfix] Fix reorganization of scss includes to allow building css
+
 ## 1.6.0
 * ViewComponent sidecar styles no longer require wrapping in `._component` class [@kdonovan]
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/teamshares/design-system.git"
   },
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "files": [
     "scss/**/*.scss",

--- a/scss/core-includes/index.scss
+++ b/scss/core-includes/index.scss
@@ -1,6 +1,4 @@
 @import 'components';
 @import 'forms';
-@import 'pagination';
-@import 'tables';
 @import 'typography';
 @import 'teamshares';


### PR DESCRIPTION
Should have gone out with 1.6.0, but I'd rebased on main and it turns out main was broken. Fixes two overlooked tweaks from [this PR](https://github.com/teamshares/design-system/pull/275).