### PR TITLE
Husky update + prepare for v1.7 release

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
 ## UNRELEASED
-* Update asset pipeline dependencies
 * Add change description here
+
+## 1.7.0
+* Update asset pipeline dependencies
+* Fix pre-commit script for Husky@9 compatibility
 
 ## 1.6.2
 * Bump to Shoelace 2.3.0

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/teamshares/design-system.git"
   },
-  "version": "1.6.2",
+  "version": "1.7.0",
   "private": true,
   "files": [
     "scss/**/*.scss",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "concurrently": "^9.0.0",
     "cypress": "^13.3.0",
     "cypress-split": "^1.3.17",
-    "husky": "9.0.11",
+    "husky": "9.1.6",
     "lint-staged": "15.2.10"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3970,10 +3970,10 @@ humanize-duration@^3.28.0:
   resolved "https://registry.yarnpkg.com/humanize-duration/-/humanize-duration-3.30.0.tgz#9be623d331116583ff90aeb6ccfdc2e79d6d7372"
   integrity sha512-NxpT0fhQTFuMTLnuu1Xp+ozNpYirQnbV3NlOjEKBYlE3uvMRu3LDuq8EPc3gVXxVYnchQfqVM4/+T9iwHPLLeA==
 
-husky@9.0.11:
-  version "9.0.11"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-9.0.11.tgz#fc91df4c756050de41b3e478b2158b87c1e79af9"
-  integrity sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==
+husky@9.1.6:
+  version "9.1.6"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.6.tgz#e23aa996b6203ab33534bdc82306b0cf2cb07d6c"
+  integrity sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==
 
 iconv-lite@0.6.3:
   version "0.6.3"


### PR DESCRIPTION
## Ticket
[Ticket](https://linear.app/teamshares/issue/PLA-634/%5Brenovate%5D-upgrade-asset-pipeline)

## Description
Couple husky tweaks + increment version so can roll out the asset pipeline dependency updates.