### PR TITLE
Cut 1.8.4 (bump esbuild)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## UNRELEASED
 * [DOC] Add release instructions to README
 
+## 1.8.4
+* Update renovates (including esbuild security release)
+
 ## 1.8.3
 * Update cypress helpers to use `force: true`
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/teamshares/design-system.git"
   },
-  "version": "1.8.3",
+  "version": "1.8.4",
   "private": true,
   "files": [
     "scss/**/*.scss",


### PR DESCRIPTION
Releasing to [unblock linters around esbuild](https://github.com/teamshares/os-app/actions/runs/13418407073/job/37484919129?pr=3025)