### PR TITLE
PRO-808 switch wrongly named vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## UNRELEASED
 * [DOC] Add release instructions to README
 
+## 1.8.6.1
+* BUGFIX: report Teamshares.isProd correctly (and removed unused isStaging)
+
 ## 1.8.6
 * Update to Shoelace 2.4.0
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/teamshares/design-system.git"
   },
-  "version": "1.8.6",
+  "version": "1.8.6.1",
   "private": true,
   "files": [
     "scss/**/*.scss",

--- a/rails-js/index.js
+++ b/rails-js/index.js
@@ -45,8 +45,8 @@ export default class Teamshares {
 
   static isTest = (Teamshares.env === "test");
   static isDev = (Teamshares.env === "development");
-  static isProd = (Teamshares.env === "staging");
-  static isStaging = (Teamshares.env === "production");
+  static isStaging = (Teamshares.env === "staging");
+  static isProd = (Teamshares.env === "production");
 
   static start (config = {}) {
     console.debug(`Initializing Teamshares JS. Environment: ${Teamshares.env}`);

--- a/rails-js/index.js
+++ b/rails-js/index.js
@@ -45,7 +45,6 @@ export default class Teamshares {
 
   static isTest = (Teamshares.env === "test");
   static isDev = (Teamshares.env === "development");
-  static isStaging = (Teamshares.env === "staging");
   static isProd = (Teamshares.env === "production");
 
   static start (config = {}) {


### PR DESCRIPTION
## Ticket
[Ticket](https://linear.app/teamshares/issue/PRO-808/are-js-issues-being-reported-to-honeybadger)


## Description
* Removed `isStaging`
* Fixed `isProd`


## Screenshots (if relevant)


> ## Release Reminder
> You'll need to push PRs to any consuming apps that need to _use_ these changes (after this PR is merged, `yarn upgrade @teamshares/design-system` in the consuming apps).
