### PR TITLE
Slh/bump to shoelace 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## UNRELEASED
 * [DOC] Add release instructions to README
 
+## 1.8.8
+* Update to Shoelace 2.5.0
+* Update `ts-card` styles to match `sl-card`
+
 ## 1.8.7
 * BUGFIX: report Teamshares.isProd correctly (and removed unused isStaging)
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/teamshares/design-system.git"
   },
-  "version": "1.8.7",
+  "version": "1.8.8",
   "private": true,
   "files": [
     "scss/**/*.scss",
@@ -26,7 +26,7 @@
     "@tailwindcss/container-queries": "0.1.1",
     "@tailwindcss/forms": "0.5.10",
     "@tailwindcss/typography": "0.5.16",
-    "@teamshares/shoelace": "2.4.0",
+    "@teamshares/shoelace": "2.5.0",
     "cli-color": "2.0.4",
     "cssnano": "7.0.6",
     "esbuild": "0.25.2",

--- a/scss/core-includes/components/_dashboard.scss
+++ b/scss/core-includes/components/_dashboard.scss
@@ -5,11 +5,10 @@
 
   @layer components {
     .ts-card {
-      @apply rounded-lg;
+      @apply rounded-lg border border-gray-300;
 
       box-shadow:
-        0 0 4px 1px rgba(0, 0, 0, 0.04),
-        0 0 0 1px rgba(0, 0, 0, 0.06);
+        0 0 4px 0 rgba(0, 0, 0, 0.04);
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1141,10 +1141,10 @@
     lodash.merge "^4.6.2"
     postcss-selector-parser "6.0.10"
 
-"@teamshares/shoelace@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@teamshares/shoelace/-/shoelace-2.4.0.tgz#7c3a8580441131059a5a7ba68b1888133ce426f0"
-  integrity sha512-2AOHsJoTm2bJ4GVnbyQk6bfZ2FD/auiDZMy0l6b9yd10Nbx2uNLTV18Jiv7KZN+eMC7Uplm9N1mGfdwDlOrChw==
+"@teamshares/shoelace@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@teamshares/shoelace/-/shoelace-2.5.0.tgz#14845ee6e0f619caa00190b4c3161f3731d9e72f"
+  integrity sha512-3WVieDv3sdxwkEQqX+kkYhhJijC+ZEQUR9rm6VI6iQT0H1cFqsqdgm+Z4WnPiLoiashx839mHWQGKBa/fFVt2Q==
   dependencies:
     "@ctrl/tinycolor" "^4.0.2"
     "@figma/code-connect" "^1.3.1"


### PR DESCRIPTION
### Cut v1.8.8
* Update to Shoelace 2.5.0
* Update `ts-card` styles to match `sl-card`