### PR TITLE
Release as 1.8.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/teamshares/design-system.git"
   },
-  "version": "1.8.9.1",
+  "version": "1.8.10",
   "private": true,
   "files": [
     "scss/**/*.scss",


### PR DESCRIPTION
When trying to install this, we get yarn errors... [apparently](https://chatgpt.com/c/68d571d1-fe64-8332-a08b-ab039e3ea508) yarn/npm only accepts three numeric parts 🤷 

> yarn install v1.22.22
> [1/4] 🔍  Resolving packages...
> error Can't add "@teamshares/design-system": invalid package version "1.8.9.1".