### PR TITLE
Fix ::part() selectors under ._base for Shoelace components

### DIFF
--- a/configs/postcss/prefix-component-classes.js
+++ b/configs/postcss/prefix-component-classes.js
@@ -19,9 +19,9 @@ const parseRule = (wrapper) => (rule) => {
     logger.debug(`\tReplacing ${clc.whiteBright(rule.selector)} with ${clc.whiteBright(wrapper)}`);
     rule.selector = wrapper;
   } else if (rule.selector.startsWith("._base")) {
-    // Check if this is a ::part() selector that should be handled specially
-    if (rule.selector.includes("::part(")) {
-      // For ::part() selectors, just replace ._base with the wrapper class
+    // Check if this is a ::part() selector directly under ._base (e.g., ._base::part(header))
+    if (rule.selector.match(/^\._base::part\(/)) {
+      // For ::part() selectors directly under ._base, just replace ._base with the wrapper class
       // The ::part() will target the Shoelace component inside the wrapper
       const newSelector = rule.selector.replace("._base", wrapper);
       logger.debug(`\tReplacing ${clc.whiteBright(rule.selector)} with ${clc.whiteBright(newSelector)} (::part() selector)`);


### PR DESCRIPTION
## Ticket
[Ticket](https://linear.app/teamshares/issue/PRO-1213/design-system-fix-pseudo-element-selectors-for-view-component-shoelace)


## Description
**Problem:** ViewComponents with Shoelace components as root elements couldn't style `::part()` pseudo-elements when using the `._base` wrapper class. Selectors like `._base::part(header)` were being dropped entirely.

**Solution:** Enhanced the PostCSS plugin to detect and properly handle `::part()` selectors directly nested under `._base`. Now `._base::part(header)` gets transformed to `.c-component-name::part(header)` instead of being dropped.

**Changes:**
- Added regex `/^\._base::part\(/` to detect direct `::part()` nesting under `._base`
- Only supports direct nesting (e.g., `._base::part(header)`) - deeper nesting still gets dropped
- Maintains existing behavior for all other selectors

**Impact:** Enables proper styling of Shoelace component parts in ViewComponent SCSS files without workarounds.