### PR TITLE
Fix TsWrapper: guard against null parentNode in connectedCallback

### DIFF
--- a/rails-js/includes/ts_wrapper.js
+++ b/rails-js/includes/ts_wrapper.js
@@ -39,6 +39,10 @@ class TsWrapper extends HTMLElement {
     topLevelElement.classList = `${this.className} ${topLevelElement.classList}`;
 
     /** Re-parent the top-level element and remove the ts-wrapper element from the DOM */
+    // parentNode can be null when Turbo connects elements into a detached subtree during
+    // frame rendering (e.g. Bardo's preservingPermanentElements). Safe to bail out: the
+    // element is not in the document so there is nothing to unwrap.
+    if (!this.parentNode) return;
     this.parentNode.insertBefore(topLevelElement, this);
     this.remove();
   }


### PR DESCRIPTION
## Problem

`TsWrapper.connectedCallback` calls `this.parentNode.insertBefore(topLevelElement, this)`. When Turbo replaces a frame, its `FrameRenderer` uses Bardo (`preservingPermanentElements`) which connects elements into a detached subtree. The browser fires `connectedCallback` on the `<ts-wrapper>` element during this process, but `parentNode` is null because the element isn't attached to the document yet.

This throws `TypeError: Cannot read properties of null (reading 'insertBefore')` as an uncaught browser exception.

## Fix

Add a null guard that bails out of `connectedCallback` early when `parentNode` is null:

```js
if (!this.parentNode) return;
this.parentNode.insertBefore(topLevelElement, this);
this.remove();
```

When `parentNode` is null the element is not in the document, so there is nothing to unwrap — returning early is the correct behavior.

## Context

Discovered via a Playwright `pageerror` listener added to system tests in teamshares/os-app. The error surfaced on the Industry Groups page when a Turbo frame containing a `<ts-wrapper>`-wrapped ViewComponent was replaced after a form submission.

Stack trace at time of discovery:
```
TypeError: Cannot read properties of null (reading 'insertBefore')
    at TsWrapper.connectedCallback
    at TsWrapper.connectedCallback
    at FrameRenderer.renderElement
    at FrameRenderer.loadFrameElement
    at Bardo.preservingPermanentElements
    at FrameRenderer.preservingPermanentElements
    at FrameRenderer.render
```