### PR TITLE
[Clean] Harden ts-wrapper: hoist orphaned Stimulus values + rewriteCloned helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## UNRELEASED
-* N/A
+* TsWrapper: transparently hoist a Stimulus `*-value` attribute up to the controller mount when it lands on a descendant (Stimulus reads static values only from `this.element`; a value on a descendant silently fell back to the type default). Throws in dev/test when a conflict cannot be auto-resolved; resolves deterministically in production.
+* TsWrapper: add `Teamshares.tsWrapper.rewriteCloned(html, identifier)` — rewrite `controller` placeholder attributes and action values in a cloned HTML string, for use when inserting `<template>` content at runtime (ts-wrapper's hydration traversal does not enter inert template fragments).
 
 ## 1.9.0
 * Major dependency updates — eslint v10, stylelint v17, eslint-plugin-n v18, eslint-plugin-cypress v6, eslint-plugin-jest v29, postcss-mixins v12 (verified no new lint errors in downstream apps)

--- a/rails-js/includes/ts_wrapper.js
+++ b/rails-js/includes/ts_wrapper.js
@@ -56,6 +56,17 @@ class TsWrapper extends HTMLElement {
     /** Find generic data-action attributes and inject the controller name */
     this.replaceDataAttributes(topLevelElement, controller);
 
+    /**
+     * Hoist any Stimulus *-value attributes that landed on a descendant of the mount up to the
+     * mount itself — Stimulus reads static values only from this.element (the controller root),
+     * so a value attribute on a descendant always silently falls back to the type default.
+     *
+     * Throws in dev/test when a conflict cannot be auto-resolved (the mount already has the same
+     * attribute with a different value, meaning two parts of the template disagree). In production,
+     * the mount value wins and the stray descendant copy is silently dropped.
+     */
+    this.hoistOrphanedValues(topLevelElement, controller);
+
     /** Add the generated class as the first in the list */
     topLevelElement.classList = `${this.className} ${topLevelElement.classList}`;
 
@@ -110,6 +121,60 @@ class TsWrapper extends HTMLElement {
       }
     }
     traverse(rootNode);
+  }
+
+  /**
+   * Move any `data-<controller>-*-value` attributes from descendants of the mount up to the
+   * mount element itself. Stimulus reads `static values` only from `this.element` (the controller
+   * root); the existing rewrite traversal correctly renames the attribute but cannot move it.
+   *
+   * Clean hoists (single occurrence, no pre-existing mount copy): always performed in all envs.
+   * Conflicts (mount already has the attribute with a different value, or two descendants disagree):
+   *   - dev/test  → throw with a descriptive message so the bug is surfaced at hydration.
+   *   - production → mount value wins; duplicate is silently dropped (deterministic, no throw).
+   *
+   * Nested <ts-wrapper> subtrees are skipped — they own their own controller identifier and value
+   * attributes; their presence cannot produce a conflict with ours.
+   */
+  hoistOrphanedValues (mount, controller) {
+    const prefix = `data-${controller}-`;
+    const isValue = (name) => name.startsWith(prefix) && name.endsWith("-value");
+    const devMode = window.Teamshares?.isDev || window.Teamshares?.isTest;
+
+    const walk = (node) => {
+      for (const child of node.children) {
+        if (child.nodeName === "TS-WRAPPER") continue; // nested component owns its own values
+
+        // Snapshot attribute names first — mutating attributes while iterating the live NamedNodeMap
+        // changes the collection length and skips entries.
+        const names = [];
+        for (const attr of child.attributes) {
+          if (isValue(attr.name)) names.push(attr.name);
+        }
+
+        for (const name of names) {
+          const value = child.getAttribute(name);
+          if (mount.hasAttribute(name)) {
+            // The mount already carries this value (either set in the template markup directly, or
+            // hoisted here from an earlier descendant). If the values differ it's an author error.
+            if (devMode && mount.getAttribute(name) !== value) {
+              throw new Error(
+                `ts-wrapper: "${name}" is set on both the "${controller}" controller mount ` +
+                `("${mount.getAttribute(name)}") and a <${child.nodeName.toLowerCase()}> descendant ` +
+                `("${value}"). Stimulus reads static values only from the mount — remove the duplicate.`,
+              );
+            }
+            child.removeAttribute(name); // prod / identical values: mount wins, drop the stray copy
+          } else {
+            mount.setAttribute(name, value); // clean hoist
+            child.removeAttribute(name);
+          }
+        }
+
+        walk(child);
+      }
+    };
+    walk(mount);
   }
 }
 

--- a/rails-js/includes/ts_wrapper.js
+++ b/rails-js/includes/ts_wrapper.js
@@ -1,3 +1,6 @@
+// process.env.RAILS_ENV is replaced at compile time by esbuild (see configs/esbuild.config.js)
+/* global process */
+
 /**
   * All view components will be wrapped in this element.
  *
@@ -139,7 +142,10 @@ class TsWrapper extends HTMLElement {
   hoistOrphanedValues (mount, controller) {
     const prefix = `data-${controller}-`;
     const isValue = (name) => name.startsWith(prefix) && name.endsWith("-value");
-    const devMode = window.Teamshares?.isDev || window.Teamshares?.isTest;
+    // process.env.RAILS_ENV is a compile-time constant (esbuild define) — using it here avoids
+    // a timing issue where connectedCallback fires (when customElements.define upgrades existing
+    // elements) before window.Teamshares is set, which happens later in index.js evaluation.
+    const devMode = process.env.RAILS_ENV !== "production";
 
     const walk = (node) => {
       for (const child of node.children) {

--- a/rails-js/includes/ts_wrapper.js
+++ b/rails-js/includes/ts_wrapper.js
@@ -6,6 +6,27 @@
  * It also provides a hook for us to add shared logging, etc. in the future.
  */
 
+/**
+ * Rewrite `controller` placeholder attributes and action values in a cloned HTML string,
+ * replacing them with the real Stimulus identifier.
+ *
+ * Use this when inserting <template> content at runtime — template fragment children live in
+ * `template.content` (a DocumentFragment outside the regular DOM tree), so ts-wrapper's hydration
+ * traversal never enters them and any `controller` placeholders survive verbatim into cloned chunks.
+ *
+ * Example:
+ *   const html = Teamshares.tsWrapper.rewriteCloned(this.rowTemplateTarget.innerHTML, this.identifier);
+ *   this.listTarget.insertAdjacentHTML("beforeend", html);
+ *
+ * Note: the bare `controller#action` shorthand (without a preceding `->`) is not rewritten here
+ * because template contexts are action-descriptor strings, not standalone prefixes.
+ */
+export function rewriteCloned (html, identifier) {
+  return html
+    .replaceAll("->controller#", `->${identifier}#`)
+    .replaceAll(/data-controller-([a-z0-9-]+)/g, `data-${identifier}-$1`);
+}
+
 class TsWrapper extends HTMLElement {
   connectedCallback () {
     let topLevelElement;

--- a/rails-js/index.js
+++ b/rails-js/index.js
@@ -4,7 +4,7 @@ import Honeybadger from "@honeybadger-io/js";
 import Rails from "@rails/ujs";
 import { Turbo } from "@hotwired/turbo-rails";
 
-import "./includes/ts_wrapper";
+import { rewriteCloned } from "./includes/ts_wrapper";
 import { registerStimulusControllers } from "./controllers";
 
 /** ********************************************************** */
@@ -46,6 +46,9 @@ export default class Teamshares {
   static isTest = (Teamshares.env === "test");
   static isDev = (Teamshares.env === "development");
   static isProd = (Teamshares.env === "production");
+
+  /** Utilities for working with ts-wrapper in Stimulus controllers */
+  static tsWrapper = { rewriteCloned };
 
   static start (config = {}) {
     console.debug(`Initializing Teamshares JS. Environment: ${Teamshares.env}`);


### PR DESCRIPTION
Closes [PRO-2558](https://linear.app/teamshares/issue/PRO-2558/clean-harden-ts-wrapper-for-inert-template-content-and-multi-root)

## Human
Update our `ts-wrapper` hoisting code to better handle edge case of using stimulus `value` attrs on the root element of a multi-root view component.

Add helper for odd edge case (only used once in OS so far) where the component contains a `template` script that is injected dynamically via JS -- need to dynamically update bare `controller` replacement too, and that'd be better as a global helper rather than one-off in that particular OS code.

## Summary

- **TsWrapper: hoist orphaned `*-value` attrs to the controller mount.** Stimulus reads `static values` only from `this.element`. When a component has multiple top-level children, ts-wrapper builds a synthetic `<div>` mount; a `data-controller-foo-value` on an inner element got its name rewritten correctly but stayed on the wrong element, causing `this.fooValue` to silently fall back to the type default (`0` / `""`). The new `hoistOrphanedValues` method (called right after `replaceDataAttributes`) moves any `data-<id>-*-value` from descendants up to the mount in all environments. On an unresolvable conflict (two parts of the template disagree on the value), it throws a descriptive `Error` in non-production so the bug surfaces at hydration rather than silently in production.
- **`Teamshares.tsWrapper.rewriteCloned(html, identifier)`.** Template fragment children live in `template.content` (outside the regular DOM tree) — ts-wrapper's hydration traversal never enters them, so `controller` placeholders survive verbatim into cloned chunks. Every component that clones template content was reinventing the same two-regex fix. This helper centralises it: `Teamshares.tsWrapper.rewriteCloned(this.rowTemplateTarget.innerHTML, this.identifier)`.

## Why not auto-detect/warn on template content?

A `<template>` legitimately contains `->controller#` placeholders until rewritten at clone time. Any hydration-time scan would false-positive on correctly-written components that call `rewriteCloned` — so we ship the helper and docs, not a warning.

## Implementation note: devMode uses `process.env.RAILS_ENV`, not `window.Teamshares`

The layout loads JS with `defer: true`. This means when the deferred bundle evaluates and hits `customElements.define("ts-wrapper", TsWrapper)`, Chrome synchronously upgrades all existing `<ts-wrapper>` elements already in the parsed DOM and fires `connectedCallback` — before `window.Teamshares` is set (that happens 90 lines later in `index.js`). Using `window.Teamshares?.isDev` would therefore always be `undefined` (falsy) at connectedCallback time.

Fix: `devMode = process.env.RAILS_ENV !== "production"` — esbuild replaces this with a compile-time string literal, so there's no runtime timing dependency. Produces `true` in development/test/staging and `false` only in production builds.

## Test plan

- [x] Verify `Teamshares.tsWrapper.rewriteCloned('<a data-action="click->controller#go" data-controller-x-value="1">', 'foo--bar')` returns the rewritten string (`->foo--bar#go`, `data-foo--bar-x-value`). ✓ Verified inline in Node.js.
- [x] Render a multi-root component with `data-controller-foo-value` on an inner element; confirm the attribute is hoisted to the mount and `this.fooValue` reads the real value (not the type default). No throw. ✓ Verified via new `Foo::HoistTest::Component` system spec in teamshares-rails — controller logged `spokesValue: 42` (not `0`).
- [x] Add a conflicting copy with a different value on the root in dev; confirm it throws with the descriptive message. ✓ Verified via new `Foo::ConflictTest::Component` system spec — browser logs contain the `ts-wrapper: "..." is set on both...` error, and `<ts-wrapper>` stays in the DOM (unwrap never ran).
- [x] Confirm production build (`RAILS_ENV=production`) never throws on the same conflict. ✓ Verified by code path: `process.env.RAILS_ENV !== "production"` compiles to `false` in production builds; the throw is unreachable.
- [x] Run existing `teamshares-rails` `ts_wrapper_spec.rb` — the dummy component (`Foo::BarQux::Baz`) is single-root with the value on the root, so no hoist occurs and the spec's existing assertions hold. ✓ All 7 specs pass (5 existing + 2 new).

## Follow-ups (tracked in PRO-2558)

- teamshares-rails spec additions (multi-root hoist + conflict + `rewriteCloned` round-trip) — after this version is published.
- os-app retrofit of `app/frontend/components/admin/employments/form/controller.js` — once PRO-2557 / os-app#4773 lands and the file exists.
- os-app `console.error` spec gate (independent; needs blast-radius pass over pre-existing errors first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)